### PR TITLE
Fix calc. of temperaturess from TFA wind sensor

### DIFF
--- a/RFXtrx/lowlevel.py
+++ b/RFXtrx/lowlevel.py
@@ -1665,10 +1665,16 @@ class Wind(SensorPacket):
         self.direction = data[6] * 256 + data[7]
         self.average_speed = data[8] * 256.0 + data[9] / 10.0
         self.gust = data[10] * 256.0 + data[11] / 10.0
-        self.temperature = (-1 * (data[12] >> 7)) * (
-            (data[12] & 0x7f) * 256.0 + data[13]) / 10.0
-        self.chill = (-1 * (data[14] >> 7)) * (
-            (data[14] & 0x7f) * 256.0 + data[15]) / 10.0
+        self.temphigh = data[12]
+        self.templow = data[13]
+        self.temperature = float(((self.temphigh & 0x7f) << 8) + self.templow) / 10
+        if self.temphigh >= 0x80:
+            self.temperature = -self.temperature
+        self.chillhigh = data[14]
+        self.chilllow = data[15]
+        self.chill = float(((self.chillhigh & 0x7f) << 8) + self.chilllow) / 10
+        if self.chillhigh >= 0x80:
+            self.chill = -self.chill
         if self.subtype == 0x03:
             self.battery = data[16] + 1 * 10
         else:


### PR DESCRIPTION
The proposed change corrects the calculation of "temperature" and "chill" for TFA anemometers (wind sensors).  Previously, values < 0 were handled properly, but all values >0 were returned as 0 (due to the multiplication of the leading bit in the first line of each statement).

The proposed change duplicates the method used in the TempHum sensor further above in the code.

This change is operating correctly in my personal setup with HomeAssistant 0.42.3 (pyRFXtrx 0.17.0).

Please note that this has *not* been run through pylint, etc., and should be reviewed by someone more familiar with Python than me.